### PR TITLE
[fix] webpack-bundle-analyzer 패키지를 devDependency에서 dependency로 옮김

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -49,7 +49,6 @@
     "msw": "^0.39.1",
     "style-loader": "^3.3.1",
     "webpack": "^5.68.0",
-    "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4",
     "webpack-merge": "^5.8.0"
@@ -62,6 +61,7 @@
     "react-router-dom": "^6.2.1",
     "socket.io-client": "^4.4.1",
     "styled-components": "^5.3.3",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "webpack-bundle-analyzer": "^4.5.0"
   }
 }

--- a/packages/webapp/webpack.prod.js
+++ b/packages/webapp/webpack.prod.js
@@ -2,6 +2,7 @@ import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import DotenvWebpackPlugin from 'dotenv-webpack';
 import { merge } from 'webpack-merge';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 import common from './webpack.common.js';
 


### PR DESCRIPTION
`webpack-bundle-analyzer` 패키지를 devDependency로 설치했더니 `production` 환경에서 빌드하는 와중에 에러가 발생하여 해당 패키지를 그냥 dependency로 설치