### PR TITLE
[feat] 자산 추이 차트 모바일 환경 최적화

### DIFF
--- a/packages/webapp/src/index.tsx
+++ b/packages/webapp/src/index.tsx
@@ -4,10 +4,6 @@ import App from '@src/App';
 import { AppProviders } from '@components/index';
 import './font.css';
 
-if (window.matchMedia('(max-width: 810px').matches) {
-	alert('현재 모바일 환경엔 최적화되어 있지 않습니다. 빠른 시일 내에 서비스하도록 하겠습니다 🙏');
-}
-
 ReactDOM.render(
 	<React.StrictMode>
 		<AppProviders>

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/constants/index.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/constants/index.ts
@@ -1,9 +1,9 @@
 export const CANVAS_TOP_MARGIN = 40;
-export const CANVAS_BOT_MARGIN = 80;
+export const CANVAS_BOT_MARGIN = 50;
 export const X_AXIS_MARGIN = 20;
-export const Y_AXIS_MARGIN = 20;
+export const Y_AXIS_MARGIN = 10;
 export const X_AXIS_LEGEND_GAP = 20;
-export const Y_AXIS_LEGEND_GAP = 5;
+export const Y_AXIS_LEGEND_GAP = 3;
 export const AXIS_THICKNESS = 2;
 export const HORIZONTAL_GRID_THICKNESS = 1;
 export const VERTICAL_GRID_THICKNESS = 1;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/constants/index.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/constants/index.ts
@@ -7,6 +7,5 @@ export const Y_AXIS_LEGEND_GAP = 5;
 export const AXIS_THICKNESS = 2;
 export const HORIZONTAL_GRID_THICKNESS = 1;
 export const VERTICAL_GRID_THICKNESS = 1;
-export const ASSET_CHART_LINE_THICKNESS = 1;
-export const CHART_VERTEX_RADIUS = 4;
+export const ASSET_CHART_LINE_THICKNESS = 2;
 export const NUM_OF_HORIZONTAL_GRID = 6;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/index.tsx
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/index.tsx
@@ -58,6 +58,7 @@ export default function AssetHistory({ portfolioId }: Props) {
 			theme,
 			minValue: minTotalAsset,
 			maxValue: adjustedMaxValue,
+			viewWidth,
 			canvasWidth,
 			canvasHeight
 		});
@@ -79,6 +80,7 @@ export default function AssetHistory({ portfolioId }: Props) {
 			theme,
 			minValue: minTotalAsset,
 			maxValue: adjustedMaxValue,
+			viewWidth,
 			canvasWidth,
 			canvasHeight,
 			chartData,

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/index.tsx
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/index.tsx
@@ -48,6 +48,7 @@ export default function AssetHistory({ portfolioId }: Props) {
 
 		const canvasWidth = assetChartCanvasGeometry.width ?? assetChartCanvas.clientWidth;
 		const canvasHeight = assetChartCanvasGeometry.height ?? assetChartCanvas.clientHeight;
+		const viewWidth = window.innerWidth;
 		const minMaxDiff = (maxTotalAsset - minTotalAsset) / (NUM_OF_HORIZONTAL_GRID - 1);
 		const adjustedMaxValue =
 			minMaxDiff < 1 ? minTotalAsset + (NUM_OF_HORIZONTAL_GRID - 1) : maxTotalAsset;
@@ -66,6 +67,7 @@ export default function AssetHistory({ portfolioId }: Props) {
 			theme,
 			minValue: minTotalAsset,
 			maxValue: adjustedMaxValue,
+			viewWidth,
 			canvasWidth,
 			canvasHeight,
 			chartData,

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/styles.ts
@@ -9,9 +9,13 @@ export const AssetHistoryContainer = styled(Card)`
 
 export const AssetHistoryChart = styled.canvas`
 	width: 100%;
-	height: 410px;
+	height: 380px;
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.laptopSmall}px) {
+		height: 300px;
+	}
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tablet}px) {
-		height: 360px;
+		height: 260px;
 	}
 `;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/styles.ts
@@ -1,16 +1,17 @@
 import styled from 'styled-components';
 import Card from '@components/Card';
-import { CANVAS_PADDING_PX, ITEM_UPPER_LOWER_PADDING_PX } from '../constants';
-
-const ASSET_HISTORY_CONTAINER_HEIGHT_PX = 420;
+import { WIDTH_BREAK_POINT_PX } from '@constants/breakPoints';
+import { ITEM_UPPER_LOWER_PADDING_PX } from '../constants';
 
 export const AssetHistoryContainer = styled(Card)`
 	padding: ${ITEM_UPPER_LOWER_PADDING_PX}px 0;
-	height: ${ASSET_HISTORY_CONTAINER_HEIGHT_PX}px;
 `;
 
 export const AssetHistoryChart = styled.canvas`
 	width: 100%;
-	height: calc(100% - ${ITEM_UPPER_LOWER_PADDING_PX * 2}px - 2px);
-	padding: ${CANVAS_PADDING_PX}px;
+	height: 410px;
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tablet}px) {
+		height: 360px;
+	}
 `;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/chartFont.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/chartFont.ts
@@ -1,0 +1,12 @@
+import { WIDTH_BREAK_POINT_PX } from '@constants/breakPoints';
+
+export function assetChartValueLegendFont(chartWidth: number) {
+	if (chartWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return 'bold 10px NotoSansKR';
+	if (chartWidth <= WIDTH_BREAK_POINT_PX.tablet) return 'bold 12px NotoSansKR';
+	return 'bold 14px NotoSansKR';
+}
+
+export function assetChartDateFont(chartWidth: number) {
+	if (chartWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return '10px NotoSansKR';
+	return '12px NotoSansKR';
+}

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/chartFont.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/chartFont.ts
@@ -1,12 +1,12 @@
 import { WIDTH_BREAK_POINT_PX } from '@constants/breakPoints';
 
-export function assetChartValueLegendFont(chartWidth: number) {
-	if (chartWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return 'bold 10px NotoSansKR';
-	if (chartWidth <= WIDTH_BREAK_POINT_PX.tablet) return 'bold 12px NotoSansKR';
+export function assetChartValueLegendFont(viewWidth: number) {
+	if (viewWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return 'bold 10px NotoSansKR';
+	if (viewWidth <= WIDTH_BREAK_POINT_PX.tablet) return 'bold 12px NotoSansKR';
 	return 'bold 14px NotoSansKR';
 }
 
-export function assetChartDateFont(chartWidth: number) {
-	if (chartWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return '10px NotoSansKR';
+export function assetChartDateFont(viewWidth: number) {
+	if (viewWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return '10px NotoSansKR';
 	return '12px NotoSansKR';
 }

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawHorizontalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawHorizontalGrid.ts
@@ -1,6 +1,7 @@
 import { Theme } from '@types';
 import { formatCurrency } from '@utils';
 import yPos from './appliedYPos';
+import { assetChartValueLegendFont } from './chartFont';
 import {
 	NUM_OF_HORIZONTAL_GRID,
 	Y_AXIS_MARGIN,
@@ -27,7 +28,7 @@ export default function drawHorizontalGrid({
 	canvasWidth,
 	canvasHeight
 }: Props) {
-	ctx.font = 'bold 14px NotoSansKR';
+	ctx.font = assetChartValueLegendFont(canvasWidth);
 
 	const HORIZONTAL_GRID_GAP = (maxValue - minValue) / (NUM_OF_HORIZONTAL_GRID - 1);
 	const legendXPos = Y_AXIS_MARGIN - Y_AXIS_LEGEND_GAP;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawHorizontalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawHorizontalGrid.ts
@@ -34,7 +34,7 @@ export default function drawHorizontalGrid({
 
 	const HORIZONTAL_GRID_GAP = (maxValue - minValue) / (NUM_OF_HORIZONTAL_GRID - 1);
 	const legendXPos = Y_AXIS_MARGIN - Y_AXIS_LEGEND_GAP;
-	const gridLength = canvasWidth - Y_AXIS_MARGIN * 2;
+	const gridLength = canvasWidth - Y_AXIS_MARGIN * 0.5;
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 
 	ctx.lineWidth = HORIZONTAL_GRID_THICKNESS;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawHorizontalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawHorizontalGrid.ts
@@ -16,6 +16,7 @@ interface Props {
 	theme: Theme;
 	minValue: number;
 	maxValue: number;
+	viewWidth: number;
 	canvasWidth: number;
 	canvasHeight: number;
 }
@@ -25,10 +26,11 @@ export default function drawHorizontalGrid({
 	theme,
 	minValue,
 	maxValue,
+	viewWidth,
 	canvasWidth,
 	canvasHeight
 }: Props) {
-	ctx.font = assetChartValueLegendFont(canvasWidth);
+	ctx.font = assetChartValueLegendFont(viewWidth);
 
 	const HORIZONTAL_GRID_GAP = (maxValue - minValue) / (NUM_OF_HORIZONTAL_GRID - 1);
 	const legendXPos = Y_AXIS_MARGIN - Y_AXIS_LEGEND_GAP;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
@@ -34,7 +34,8 @@ export default function drawLine({
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 	let xPos = maxTextWidth + Y_AXIS_MARGIN + Y_AXIS_LEGEND_GAP;
 	const verticalGridGap =
-		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 3 - Y_AXIS_LEGEND_GAP) / (numOfVerticalGrids - 1);
+		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 1.5 - Y_AXIS_LEGEND_GAP) /
+		(numOfVerticalGrids - 1);
 
 	for (let i = chartData.length - 1; i >= 0; i--) {
 		if (i > 0) {

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
@@ -2,12 +2,7 @@ import { AssetChartData, Theme } from '@types';
 import { formatCurrency } from '@utils';
 import yPos from './appliedYPos';
 import { assetChartValueLegendFont } from './chartFont';
-import {
-	Y_AXIS_LEGEND_GAP,
-	Y_AXIS_MARGIN,
-	CHART_VERTEX_RADIUS,
-	ASSET_CHART_LINE_THICKNESS
-} from '../constants';
+import { Y_AXIS_LEGEND_GAP, Y_AXIS_MARGIN, ASSET_CHART_LINE_THICKNESS } from '../constants';
 import { assetChartLineColor } from '../../colors';
 import { crispPixel } from '../../utils';
 
@@ -42,20 +37,10 @@ export default function drawLine({
 		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 3 - Y_AXIS_LEGEND_GAP) / (numOfVerticalGrids - 1);
 
 	for (let i = chartData.length - 1; i >= 0; i--) {
-		ctx.fillStyle = assetChartLineColor(theme);
-		ctx.beginPath();
-		ctx.arc(
-			Math.floor(xPos),
-			yPos({ canvasHeight, value: chartData[i].totalAsset, minValue, maxValue }),
-			CHART_VERTEX_RADIUS,
-			0,
-			2 * Math.PI
-		);
-		ctx.fill();
-
 		if (i > 0) {
 			ctx.beginPath();
 			ctx.strokeStyle = assetChartLineColor(theme);
+			ctx.lineWidth = ASSET_CHART_LINE_THICKNESS;
 			ctx.moveTo(
 				crispPixel(xPos, ASSET_CHART_LINE_THICKNESS),
 				crispPixel(

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
@@ -14,6 +14,7 @@ import { crispPixel } from '../../utils';
 interface Props {
 	ctx: CanvasRenderingContext2D;
 	theme: Theme;
+	viewWidth: number;
 	canvasWidth: number;
 	canvasHeight: number;
 	minValue: number;
@@ -25,6 +26,7 @@ interface Props {
 export default function drawLine({
 	ctx,
 	theme,
+	viewWidth,
 	canvasWidth,
 	canvasHeight,
 	minValue,
@@ -32,7 +34,7 @@ export default function drawLine({
 	chartData,
 	numOfVerticalGrids
 }: Props) {
-	ctx.font = assetChartValueLegendFont(canvasWidth);
+	ctx.font = assetChartValueLegendFont(viewWidth);
 
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 	let xPos = maxTextWidth + Y_AXIS_MARGIN + Y_AXIS_LEGEND_GAP;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawLine.ts
@@ -1,6 +1,7 @@
 import { AssetChartData, Theme } from '@types';
 import { formatCurrency } from '@utils';
 import yPos from './appliedYPos';
+import { assetChartValueLegendFont } from './chartFont';
 import {
 	Y_AXIS_LEGEND_GAP,
 	Y_AXIS_MARGIN,
@@ -31,7 +32,7 @@ export default function drawLine({
 	chartData,
 	numOfVerticalGrids
 }: Props) {
-	ctx.font = 'bold 14px NotoSansKR';
+	ctx.font = assetChartValueLegendFont(canvasWidth);
 
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 	let xPos = maxTextWidth + Y_AXIS_MARGIN + Y_AXIS_LEGEND_GAP;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
@@ -38,7 +38,8 @@ export default function drawVerticalGrid({
 	ctx.font = assetChartValueLegendFont(viewWidth);
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 	const verticalGridGap =
-		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 3 - Y_AXIS_LEGEND_GAP) / (numOfVerticalGrids - 1);
+		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 1.5 - Y_AXIS_LEGEND_GAP) /
+		(numOfVerticalGrids - 1);
 
 	ctx.lineWidth = VERTICAL_GRID_THICKNESS;
 	ctx.strokeStyle = gridColor(theme);
@@ -66,6 +67,10 @@ export default function drawVerticalGrid({
 			);
 
 			if (i < chartData.length) {
+				if (i === chartData.length - 1) {
+					ctx.textAlign = 'right';
+					gridXPos += 4;
+				}
 				ctx.fillText(
 					formatChartDateText(chartData.at(-(i + 1))!.createdAt),
 					Math.floor(gridXPos),

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
@@ -1,6 +1,7 @@
 import { Theme, AssetChartData } from '@types';
 import { formatCurrency } from '@utils';
 import yPos from './appliedYPos';
+import { assetChartDateFont, assetChartValueLegendFont } from './chartFont';
 import {
 	VERTICAL_GRID_THICKNESS,
 	X_AXIS_LEGEND_GAP,
@@ -31,7 +32,7 @@ export default function drawVerticalGrid({
 	chartData,
 	numOfVerticalGrids
 }: Props) {
-	ctx.font = 'bold 14px NotoSansKR';
+	ctx.font = assetChartValueLegendFont(canvasWidth);
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 	const verticalGridGap =
 		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 3 - Y_AXIS_LEGEND_GAP) / (numOfVerticalGrids - 1);
@@ -39,7 +40,7 @@ export default function drawVerticalGrid({
 	ctx.lineWidth = VERTICAL_GRID_THICKNESS;
 	ctx.strokeStyle = gridColor(theme);
 	ctx.textAlign = 'center';
-	ctx.font = '12px NotoSansKR';
+	ctx.font = assetChartDateFont(canvasWidth);
 	ctx.beginPath();
 
 	let gridXPos = maxTextWidth + Y_AXIS_MARGIN + Y_AXIS_LEGEND_GAP;

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
@@ -35,7 +35,7 @@ export default function drawVerticalGrid({
 	chartData,
 	numOfVerticalGrids
 }: Props) {
-	ctx.font = assetChartValueLegendFont(canvasWidth);
+	ctx.font = assetChartValueLegendFont(viewWidth);
 	const maxTextWidth = ctx.measureText(formatCurrency(maxValue, 'usd')).width;
 	const verticalGridGap =
 		(canvasWidth - maxTextWidth - Y_AXIS_MARGIN * 3 - Y_AXIS_LEGEND_GAP) / (numOfVerticalGrids - 1);

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/utils/drawVerticalGrid.ts
@@ -1,3 +1,4 @@
+import { WIDTH_BREAK_POINT_PX } from '@constants/breakPoints';
 import { Theme, AssetChartData } from '@types';
 import { formatCurrency } from '@utils';
 import yPos from './appliedYPos';
@@ -14,6 +15,7 @@ import { textColor, gridColor } from '../../colors';
 interface Props {
 	ctx: CanvasRenderingContext2D;
 	theme: Theme;
+	viewWidth: number;
 	canvasWidth: number;
 	canvasHeight: number;
 	minValue: number;
@@ -25,6 +27,7 @@ interface Props {
 export default function drawVerticalGrid({
 	ctx,
 	theme,
+	viewWidth,
 	canvasWidth,
 	canvasHeight,
 	minValue,
@@ -46,27 +49,31 @@ export default function drawVerticalGrid({
 	let gridXPos = maxTextWidth + Y_AXIS_MARGIN + Y_AXIS_LEGEND_GAP;
 	for (let i = 0; i < numOfVerticalGrids; i++) {
 		ctx.fillStyle = textColor(theme);
-		ctx.moveTo(
-			crispPixel(gridXPos, VERTICAL_GRID_THICKNESS),
-			crispPixel(
-				yPos({ canvasHeight, value: maxValue, minValue, maxValue }),
-				VERTICAL_GRID_THICKNESS
-			)
-		);
-		ctx.lineTo(
-			crispPixel(gridXPos, VERTICAL_GRID_THICKNESS),
-			crispPixel(
-				yPos({ canvasHeight, value: minValue, minValue, maxValue }),
-				VERTICAL_GRID_THICKNESS
-			)
-		);
-		if (i < chartData.length) {
-			ctx.fillText(
-				formatChartDateText(chartData.at(-(i + 1))!.createdAt),
-				Math.floor(gridXPos),
-				yPos({ canvasHeight, value: minValue, minValue, maxValue }) + X_AXIS_LEGEND_GAP
+		if (limitNumOfVerticalGrid(i, viewWidth)) {
+			ctx.moveTo(
+				crispPixel(gridXPos, VERTICAL_GRID_THICKNESS),
+				crispPixel(
+					yPos({ canvasHeight, value: maxValue, minValue, maxValue }),
+					VERTICAL_GRID_THICKNESS
+				)
 			);
+			ctx.lineTo(
+				crispPixel(gridXPos, VERTICAL_GRID_THICKNESS),
+				crispPixel(
+					yPos({ canvasHeight, value: minValue, minValue, maxValue }),
+					VERTICAL_GRID_THICKNESS
+				)
+			);
+
+			if (i < chartData.length) {
+				ctx.fillText(
+					formatChartDateText(chartData.at(-(i + 1))!.createdAt),
+					Math.floor(gridXPos),
+					yPos({ canvasHeight, value: minValue, minValue, maxValue }) + X_AXIS_LEGEND_GAP
+				);
+			}
 		}
+
 		gridXPos += verticalGridGap;
 	}
 	ctx.stroke();
@@ -74,4 +81,11 @@ export default function drawVerticalGrid({
 
 function formatChartDateText(text: string) {
 	return text.slice(2, 10).replace(/-/g, '/');
+}
+
+function limitNumOfVerticalGrid(idx: number, viewWidth: number) {
+	if (viewWidth > WIDTH_BREAK_POINT_PX.laptop) return true;
+	if (viewWidth <= WIDTH_BREAK_POINT_PX.mobileLandScape) return idx % 4 === 1;
+	if (viewWidth <= WIDTH_BREAK_POINT_PX.tablet) return idx % 3 === 1;
+	return idx % 2 === 1;
 }

--- a/packages/webapp/src/pages/Dashboard/ProportionByValue/ProportionChartDetails.tsx
+++ b/packages/webapp/src/pages/Dashboard/ProportionByValue/ProportionChartDetails.tsx
@@ -24,7 +24,7 @@ export default function ProportionChartDetails({ chartData, maxRatio, numOfBars 
 					<Style.DetailListDataItem>평가 금액</Style.DetailListDataItem>
 					<Style.DetailListRatioItem>비중</Style.DetailListRatioItem>
 				</Style.DetailsListHeaders>
-				<Style.DetailsListContainer>
+				<Style.DetailsListContainer baseHeight={365}>
 					<ListItems
 						isListEmpty={chartData.length === 0}
 						emptyListNoticeMessage="보유 종목이 없습니다."

--- a/packages/webapp/src/pages/Dashboard/ProportionByValue/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/ProportionByValue/styles.ts
@@ -1,11 +1,17 @@
 import styled from 'styled-components';
 import { WIDTH_BREAK_POINT_PX } from '@constants/breakPoints';
+import { CANVAS_PADDING_PX } from '../constants';
 
 export const ProportionByValueChartCanvas = styled.canvas`
 	width: 100%;
 	height: 410px;
+	padding: ${CANVAS_PADDING_PX}px;
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
 		height: 380px;
+	}
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
+		padding: ${CANVAS_PADDING_PX}px 0;
 	}
 `;

--- a/packages/webapp/src/pages/Dashboard/SectorPieChart/SectorChartDetails.tsx
+++ b/packages/webapp/src/pages/Dashboard/SectorPieChart/SectorChartDetails.tsx
@@ -23,7 +23,7 @@ export default function SectorChartDetails({ chartData, maxRatio, numOfPies }: P
 					<Style.DetailListDataItem>구성 종목</Style.DetailListDataItem>
 					<Style.DetailListRatioItem>비중</Style.DetailListRatioItem>
 				</Style.DetailsListHeaders>
-				<Style.DetailsListContainer>
+				<Style.DetailsListContainer baseHeight={255}>
 					<ListItems
 						isListEmpty={chartData.length === 0}
 						emptyListNoticeMessage="보유 종목이 없습니다."

--- a/packages/webapp/src/pages/Dashboard/SectorPieChart/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/SectorPieChart/styles.ts
@@ -17,13 +17,19 @@ export const PieChartContainer = styled.div`
 `;
 
 export const PieChartCanvas = styled.canvas`
-	aspect-ratio: 1 / 1;
-	padding: ${CANVAS_PADDING_PX * 7}px;
-	width: 100%;
-	height: 410px;
+	width: 300px;
+	height: 300px;
+	margin: 0 auto;
+	padding: ${CANVAS_PADDING_PX}px;
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
-		height: 380px;
+		width: 280px;
+		height: 280px;
+	}
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
+		width: 240px;
+		height: 240px;
 	}
 `;
 
@@ -32,10 +38,13 @@ export const LegendContainer = styled.div`
 	display: flex;
 	align-items: center;
 	font-size: 14px;
+	max-width: 310px;
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
 		font-size: 13px;
 		width: 100%;
+		max-width: none;
+		margin-top: 12px;
 		justify-content: center;
 	}
 `;

--- a/packages/webapp/src/pages/Dashboard/colors/index.ts
+++ b/packages/webapp/src/pages/Dashboard/colors/index.ts
@@ -7,7 +7,7 @@ export function textColor(theme: Theme) {
 }
 
 export function gridColor(theme: Theme) {
-	return theme === 'light' ? `hsl(210, 11%, 50%)` : `hsl(210, 11%, 70%)`;
+	return theme === 'light' ? `hsl(210, 11%, 85%)` : `hsl(210, 11%, 30%)`;
 }
 
 export function assetChartLineColor(theme: Theme) {

--- a/packages/webapp/src/pages/Dashboard/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/styles.ts
@@ -197,7 +197,7 @@ export const DetailListRatioColorBar = styled.div<RatioColorBarProps>`
 export const DetailListRatioText = styled.p`
 	position: absolute;
 	top: 3px;
-	left: 4px;
+	left: 7px;
 	z-index: 1;
 `;
 

--- a/packages/webapp/src/pages/Dashboard/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/styles.ts
@@ -31,8 +31,12 @@ export const DashboardContainer = styled.div`
 	flex-direction: column;
 	gap: 40px;
 
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.laptopSmall}px) {
+		padding: 20px 14px 30px;
+	}
+
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
-		padding: 20px 2px;
+		padding: 20px 4px 40px;
 	}
 `;
 

--- a/packages/webapp/src/pages/Dashboard/styles.ts
+++ b/packages/webapp/src/pages/Dashboard/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 import { WIDTH_BREAK_POINT_PX } from '@constants/breakPoints';
 import Card from '@components/Card';
-import { CANVAS_PADDING_PX, ITEM_UPPER_LOWER_PADDING_PX } from './constants';
+import { ITEM_UPPER_LOWER_PADDING_PX } from './constants';
 
 const DETAIL_LIST_INDEX_ITEM_WIDTH_PX = 130;
 const DETAIL_LIST_DATA_ITEM_WIDTH_PX = 200;
@@ -15,6 +15,10 @@ interface RatioColorBarProps {
 	width: number;
 }
 
+interface DetailsListContainerProps {
+	baseHeight: number;
+}
+
 const detailListItemStyle = css`
 	padding: 4px 6px;
 `;
@@ -26,6 +30,10 @@ export const DashboardContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: 40px;
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
+		padding: 20px 2px;
+	}
 `;
 
 export const ItemIconContainer = styled.div<ItemIconBgColorProp>`
@@ -65,6 +73,10 @@ export const PortfolioSelectContainer = styled.div`
 	& > select {
 		margin: 0;
 	}
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.laptopSmall}px) {
+		margin: 0 auto;
+	}
 `;
 
 export const SelectNumOfItemsContainer = styled.div`
@@ -96,6 +108,10 @@ export const ProportionAndSectorChartSection = styled.section`
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
 		flex-direction: column;
 	}
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
+		gap: 40px;
+	}
 `;
 
 export const ProportionAndSectorChartContainer = styled(Card)`
@@ -103,7 +119,7 @@ export const ProportionAndSectorChartContainer = styled(Card)`
 	flex-direction: column;
 	width: 65%;
 	height: 100%;
-	padding: ${CANVAS_PADDING_PX}px;
+	padding: ${ITEM_UPPER_LOWER_PADDING_PX}px 4px;
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
 		width: 100%;
@@ -113,19 +129,27 @@ export const ProportionAndSectorChartContainer = styled(Card)`
 export const DetailsContainer = styled(Card)`
 	width: 35%;
 	height: 100%;
-	padding: ${CANVAS_PADDING_PX}px 4px;
+	padding: ${ITEM_UPPER_LOWER_PADDING_PX}px 4px;
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
 		width: 100%;
 		height: 310px;
 	}
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
+		height: 262px;
+	}
 `;
 
-export const DetailsListContainer = styled.div`
-	height: 365px;
+export const DetailsListContainer = styled.div<DetailsListContainerProps>`
+	height: ${({ baseHeight }) => baseHeight}px;
 
 	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.tabletLandScape}px) {
 		height: 230px;
+	}
+
+	@media screen and (max-width: ${WIDTH_BREAK_POINT_PX.mobileLandScape}px) {
+		height: 180px;
 	}
 `;
 


### PR DESCRIPTION
모바힐 환경과 같이 화면의 너비가 작은 경우 차트의 수직 grid 개수를 줄이고 캔버스 크기를 최대한 화면 너비만큼 채우도록 레이아웃 수정