### PR TITLE
[fix] asyncThrottleAndDebounce 함수 로직 수정 및 종목 검색 로직 수정

### DIFF
--- a/packages/webapp/src/api/stock/searchTickers.ts
+++ b/packages/webapp/src/api/stock/searchTickers.ts
@@ -9,7 +9,6 @@ interface ResponseType {
 export default async function searchTickers(query: string): Promise<SearchSymbolItem[]> {
 	const { apiServerUrl } = envConfig;
 
-	if (query === '') return [];
 	try {
 		const { data } = (await axios.get(
 			`${apiServerUrl}/stock/query?search=${query}`

--- a/packages/webapp/src/components/SearchStocks/index.tsx
+++ b/packages/webapp/src/components/SearchStocks/index.tsx
@@ -34,6 +34,7 @@ export default function SearchStocks({ onResultClick }: Props) {
 	useEffect(() => {
 		let shouldCancel = false;
 		if (shouldCancel) return () => {};
+		if (searchQuery === '') return () => {};
 		querySymbol(searchQuery, setSearchResults);
 
 		return () => {

--- a/packages/webapp/src/utils/asyncThrottleAndDebounce.ts
+++ b/packages/webapp/src/utils/asyncThrottleAndDebounce.ts
@@ -6,17 +6,14 @@ export default function asyncThrottleAndDebounce<T extends (...args: any) => any
 	callback: T,
 	limit: number
 ): ThrottledFunction<T> {
-	let wait = false;
+	let lastCalledTime = 0;
 	let timer: NodeJS.Timeout;
 	return async (...args: any): Promise<ReturnType<any>> => {
 		clearTimeout(timer);
 		timer = setTimeout(() => callback(...args), limit);
-		if (!wait) {
-			callback(...args);
-			wait = true;
-			setTimeout(() => {
-				wait = false;
-			}, limit);
-		}
+		const now = Date.now();
+		if (now - lastCalledTime < limit) return;
+		callback(...args);
+		lastCalledTime = now;
 	};
 }


### PR DESCRIPTION
- throttle 로직 구현 방식을 `setTimeout` 기반에서 `Date.now()` 기반으로 수정
- `SearchStocks` 컴포넌트가 최초 마운트 될 때 빈 문자열을 인자로 하여 querySymbol 함수를 호출하던 부분을 수정