### PR TITLE
[feat] 유저의 로그인 여부 체크 로직 수정

### DIFF
--- a/packages/server/src/api/auth/google.ts
+++ b/packages/server/src/api/auth/google.ts
@@ -42,6 +42,12 @@ export default (): express.Router => {
 				});
 				cookieService.issueCookie({
 					res,
+					name: 'ust',
+					value: 'y',
+					options: { httpOnly: false, maxAge: Number(envConfig.maxCookieAge ?? 0) }
+				});
+				cookieService.issueCookie({
+					res,
 					name: 'login_token',
 					value: sessionId
 				});
@@ -55,6 +61,12 @@ export default (): express.Router => {
 				name: 'uaat',
 				value: sessionId,
 				options: { maxAge: Number(envConfig.maxCookieAge ?? 0) }
+			});
+			cookieService.issueCookie({
+				res,
+				name: 'ust',
+				value: 'y',
+				options: { httpOnly: false, maxAge: Number(envConfig.maxCookieAge ?? 0) }
 			});
 			cookieService.issueCookie({
 				res,

--- a/packages/server/src/api/auth/logOut.ts
+++ b/packages/server/src/api/auth/logOut.ts
@@ -10,6 +10,7 @@ export default (): express.Router => {
 			const { uaat } = req.cookies;
 			await sessionService.deleteSession(uaat);
 			cookieService.expireCookie(res, 'uaat');
+			cookieService.expireCookie(res, 'ust');
 			res.send();
 		} catch (error) {
 			next(error);

--- a/packages/webapp/src/hooks/Auth/index.tsx
+++ b/packages/webapp/src/hooks/Auth/index.tsx
@@ -11,7 +11,8 @@ const AuthContext = React.createContext<boolean | null>(null);
 const AuthUpdateContext = React.createContext<AuthUpdateState | null>(null);
 
 export function AuthContextProvider({ children, initialValue = false }: ProviderProps) {
-	const [isAuthenticated, setIsAuthenticated] = React.useState(initialValue);
+	const initialSession = !!document.cookie.split('; ').find(row => row.startsWith('ust='));
+	const [isAuthenticated, setIsAuthenticated] = React.useState(initialValue || initialSession);
 
 	return (
 		<AuthContext.Provider value={isAuthenticated}>

--- a/packages/webapp/src/hooks/checkSession/index.ts
+++ b/packages/webapp/src/hooks/checkSession/index.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 import { useToast } from 'super-simple-react-toast';
 import { checkAuth } from '@api/auth';
 import { useAuthUpdate } from '@hooks/index';
@@ -8,15 +8,21 @@ interface Props {
 	requireLoginMessage?: boolean;
 }
 
+const THROTTLE_LIMIT = 1000 * 60 * 10;
+let lastCalledTime = 0;
+
 export default function useCheckSession({ routePath, requireLoginMessage = false }: Props) {
 	const toast = useToast();
 	const setAuth = useAuthUpdate();
 
-	useLayoutEffect(() => {
+	useEffect(() => {
 		async function tryLogIn() {
+			const now = Date.now();
+			if (now - lastCalledTime < THROTTLE_LIMIT) return;
 			const { userId, isInitialLogin } = await checkAuth();
 
 			setAuth(!!userId);
+			lastCalledTime = now;
 			if (requireLoginMessage && !userId) {
 				toast.error({ message: '세션이 만료되었습니다. 다시 로그인해주세요.' });
 			}


### PR DESCRIPTION
1. 서버에서 세션 쿠키를 내려줄 때, `httpOnly: false`로 설정되어 현재 유저가 로그인되어 있는지를 나타내는 또 다른 쿠키를 내려주도록 함. 그러면 프론트단에선 `Document.cookie`를 통해 이 쿠키의 존재여부를 파악하여 `isAuthenticated` 상태의 초기값을 설정하도록 함으로써 `PrivateRoute` 에서 새로고침을 하면 항상 홈페이지로 가는 문제를 해결하였음.
2. 유저가 route를 변경할 때마다 서버에 세션 체크 요청을 보내는 것이 불필요한 동작이라고 생각하여 이 로직에 10분짜리 쓰로틀링을 걸어
10분 간격으로 세션 체크를 하도록 수정.