### PR TITLE
[fix] styled-component 관련 바벨 설정 및 접근성 이슈 해결

### DIFF
--- a/packages/webapp/.babelrc.json
+++ b/packages/webapp/.babelrc.json
@@ -26,9 +26,6 @@
       {
         "regenerator": true
       }
-    ],
-    [
-      "babel-plugin-styled-components"
     ]
   ]
 }

--- a/packages/webapp/src/components/SearchStocks/SearchResultList.tsx
+++ b/packages/webapp/src/components/SearchStocks/SearchResultList.tsx
@@ -12,8 +12,8 @@ interface Props {
 }
 
 export default function SearchResultList({ searchQuery, searchResults, onResultClick }: Props) {
-	const outerContainerRef = useRef<HTMLUListElement>(null);
-	const innerContainerRef = useRef<HTMLDivElement>(null);
+	const outerContainerRef = useRef<HTMLDivElement>(null);
+	const innerContainerRef = useRef<HTMLUListElement>(null);
 	const { VerticalScrollBarThumb, calculateThumbY, verticalThumbH, verticalThumbRef } =
 		useVerticalScrollBar({
 			innerContainerRef,
@@ -24,9 +24,9 @@ export default function SearchResultList({ searchQuery, searchResults, onResultC
 	return (
 		<Style.SearchResultContainer ref={outerContainerRef} onScroll={calculateThumbY}>
 			<VerticalScrollBarThumb ref={verticalThumbRef} height={verticalThumbH} />
-			<div ref={innerContainerRef}>
+			<Style.SearchResultList ref={innerContainerRef}>
 				{searchResults.map(({ ticker, name, exchange, type }) => (
-					<Style.SearchListItem
+					<Style.SearchResultListItem
 						id="search-list-item"
 						key={`${ticker}${uuid()}`}
 						onClick={() => onResultClick(ticker, name)}
@@ -37,9 +37,9 @@ export default function SearchResultList({ searchQuery, searchResults, onResultC
 							<Style.SearchResultType>{stockTypeKor[type]}-</Style.SearchResultType>
 							<Style.SearchResultExchange>{exchange}</Style.SearchResultExchange>
 						</Style.SearchResultLowerSection>
-					</Style.SearchListItem>
+					</Style.SearchResultListItem>
 				))}
-			</div>
+			</Style.SearchResultList>
 		</Style.SearchResultContainer>
 	);
 }

--- a/packages/webapp/src/components/SearchStocks/styles.ts
+++ b/packages/webapp/src/components/SearchStocks/styles.ts
@@ -35,15 +35,12 @@ export const Input = styled.input`
 	}
 `;
 
-export const SearchResultContainer = styled.ul`
+export const SearchResultContainer = styled.div`
 	position: absolute;
 	z-index: 2;
 	top: 34px;
 	left: 0px;
 	width: 100%;
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
 	max-height: 300px;
 	overflow-y: scroll;
 	background-color: var(--navbarBgColor);
@@ -54,7 +51,13 @@ export const SearchResultContainer = styled.ul`
 	}
 `;
 
-export const SearchListItem = styled.li`
+export const SearchResultList = styled.ul`
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+`;
+
+export const SearchResultListItem = styled.li`
 	display: flex;
 	flex-direction: column;
 	padding: 8px 3px;

--- a/packages/webapp/src/pages/Home/Main/TopStocks.tsx
+++ b/packages/webapp/src/pages/Home/Main/TopStocks.tsx
@@ -11,7 +11,7 @@ export default function TopStocks({ stockList }: Props) {
 	if (!stockList) return <TopStocksSkeleton />;
 
 	return (
-		<>
+		<Style.TopStocksListItems>
 			{stockList.map(({ ticker, changePercent, price }) => (
 				<Style.TopStocksListItem key={ticker} as="li" bgColorOnHover>
 					<Style.TopStocksListItemLink to={`stock/${ticker}/chart`}>
@@ -25,6 +25,6 @@ export default function TopStocks({ stockList }: Props) {
 					</Style.TopStocksListItemLink>
 				</Style.TopStocksListItem>
 			))}
-		</>
+		</Style.TopStocksListItems>
 	);
 }

--- a/packages/webapp/src/pages/Home/Main/TopStocksSkeleton.tsx
+++ b/packages/webapp/src/pages/Home/Main/TopStocksSkeleton.tsx
@@ -4,7 +4,7 @@ import * as Style from './styles';
 
 export default function TopStocksSkeleton() {
 	return (
-		<>
+		<Style.TopStocksListItems>
 			{[0, 1, 2, 3, 4].map(key => (
 				<Style.TopStocksListItem key={key} as="li">
 					<SkeletonWrapper>
@@ -14,7 +14,7 @@ export default function TopStocksSkeleton() {
 					</SkeletonWrapper>
 				</Style.TopStocksListItem>
 			))}
-		</>
+		</Style.TopStocksListItems>
 	);
 }
 

--- a/packages/webapp/src/pages/Home/Main/index.tsx
+++ b/packages/webapp/src/pages/Home/Main/index.tsx
@@ -55,7 +55,6 @@ export default function Home() {
 						<AngleRight />
 					</Style.TopStocksListHeader>
 					<TopStocks stockList={topActives?.slice(0, 5)} />
-					<Style.TopStocksListItems />
 				</Style.TopStocksListSection>
 				<Style.TopStocksListSection>
 					<Style.TopStocksListHeader to="/most-gainers">
@@ -63,7 +62,6 @@ export default function Home() {
 						<AngleRight />
 					</Style.TopStocksListHeader>
 					<TopStocks stockList={topGainers?.slice(0, 5)} />
-					<Style.TopStocksListItems />
 				</Style.TopStocksListSection>
 				<Style.TopStocksListSection>
 					<Style.TopStocksListHeader to="/most-losers">
@@ -71,7 +69,6 @@ export default function Home() {
 						<AngleRight />
 					</Style.TopStocksListHeader>
 					<TopStocks stockList={topLosers?.slice(0, 5)} />
-					<Style.TopStocksListItems />
 				</Style.TopStocksListSection>
 			</Style.LowerSection>
 		</>

--- a/packages/webapp/webpack.dev.js
+++ b/packages/webapp/webpack.dev.js
@@ -17,6 +17,20 @@ export default merge(common, {
 		open: true,
 		https: true
 	},
+	module: {
+		rules: [
+			{
+				test: /\.(js|jsx|ts|tsx)$/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						plugins: ['babel-plugin-styled-components']
+					}
+				},
+				exclude: /node_modules/
+			}
+		]
+	},
 	plugins: [
 		new DotenvWebpackPlugin({
 			path: path.resolve(dirname(fileURLToPath(import.meta.url)), '.dev.env')


### PR DESCRIPTION
- `babel-plugin-styled-components` 바벨 플러그인을 개발 모드에서만 적용되도록 수정
- 접근성 측면에서 `<li>` 요소는 `<ul>` 혹은 `<ol>` 요소의 자식인게 바람직한데, 홈페이지에 표시되는 상위 5개 종목 리스트와 검색 결과를 표시하는 `SearchResultList` 컴포넌트에선 `<li>` 요소가 `<div>` 혹은 `<section>`의 자식이 되는 구조였음. 이를 수정함.