### PR TITLE
[fix] 자산 추이 차트 로딩 시 차트가 슬라이드되지 않도록 하여 빈 차트가 그려지는 버그 수정

### DIFF
--- a/packages/webapp/src/pages/Dashboard/AssetHistory/hooks/useChartDataBuffer.tsx
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/hooks/useChartDataBuffer.tsx
@@ -66,5 +66,5 @@ export default function useChartDataBuffer({ portfolioId, count, currentWindow }
 		})();
 	}, [chartDataBuffer, currentWindow, portfolioId, count]);
 
-	return { chartDataBuffer, isReachedEnd };
+	return { chartDataBuffer, isReachedEnd, isLoadingData };
 }

--- a/packages/webapp/src/pages/Dashboard/AssetHistory/index.tsx
+++ b/packages/webapp/src/pages/Dashboard/AssetHistory/index.tsx
@@ -21,7 +21,7 @@ export default function AssetHistory({ portfolioId }: Props) {
 	const [theme] = useThemeMode();
 	const assetChartRef = useRef<HTMLCanvasElement>(null);
 	const [currentWindow, setCurrentWindow] = useState({ s: 0, e: COUNT - 1 });
-	const { chartDataBuffer, isReachedEnd } = useChartDataBuffer({
+	const { chartDataBuffer, isReachedEnd, isLoadingData } = useChartDataBuffer({
 		portfolioId,
 		count: COUNT,
 		currentWindow
@@ -110,6 +110,7 @@ export default function AssetHistory({ portfolioId }: Props) {
 	function slideChart(e: MouseEvent<HTMLCanvasElement>) {
 		if (!isGrabbedChart.current) return;
 		if (!assetChartRef.current) return;
+		if (isLoadingData.current) return;
 
 		e.preventDefault();
 		const dx = startXPos.current - e.clientX;


### PR DESCRIPTION
네트워크가 좋지 않은 환경에서 차트 데이터를 추가로 받아오는 지연시간으로 인해 데이터를 채 받아오기도 전에 `window`가 `chartBufferData` 보다 앞서는 현상이 있었음. 이로 인해 아래와 같이 빈 차트가 그려지는 버그가 있었는데, 차트 데이터를 받아오는 도중엔 슬라이드 되지 않도록 하여 해결하였음.

- Before:
![asset-chart-before](https://user-images.githubusercontent.com/50892653/176068228-f37306d5-843c-47e4-82ae-a222a3e23ae1.gif)

- After
![asset-chart-after](https://user-images.githubusercontent.com/50892653/176068237-3f25071b-516a-4fbd-b12a-7cca1a6c7646.gif)

하지만 이렇게 하니 차트가 뚝뚝 끊겨 보여지는 현상이 있어 사용자 관점에서 좋지 못하다고 생각됨. 따라서 추가 데이터를 로딩중이라는 문구를 추가하던지, 아니면 날짜만 미리 표시하고 비어있는 차트를 보여준 뒤 데이터를 받아오면 그때 보여주는 방법도 있을듯함.